### PR TITLE
Fix Cleric Yaulp

### DIFF
--- a/Macros/e3 Includes/e3_Classes_Cleric.inc
+++ b/Macros/e3 Includes/e3_Classes_Cleric.inc
@@ -16,7 +16,7 @@ SUB event_manastone
 |----------------------------------------------------------------------------|
 SUB check_Yaulp
 /if (${Debug}) /echo |- check_clrYaulp ==>
-  /if (${AutoYaulp} && !${medBreak})  {
+  /if (${AutoYaulp} && !${medBreak} && !${Me.Moving})  {
     /declare castName string local ${yaulpSpell.Arg[1,/]}
     /if (!${Bool[${Me.Buff[${castName}]}]} && ${Me.PctMana} < 95 && ${Spell[${castName}].NewStacks}) {
       /if (${Target.ID}) /declare tempTarget int local ${Target.ID}


### PR DESCRIPTION
If you have auto-yaulp setup, the cleric was prone to stopping while following the group and getting left behind. This fixes that by adding a check to not cast if moving.